### PR TITLE
Use environment variable for core | install item title

### DIFF
--- a/tasks/core.yml
+++ b/tasks/core.yml
@@ -47,10 +47,12 @@
     - wordpress-core-is-installed
 
 - name: core | install
+  environment:
+    ITEM_TITLE: "{{ item.item.title }}"
   command: >
     wp-cli core install
     --allow-root --no-color --path='{{ item.item.path }}'
-    --url='{{ item.item.url }}' --title='{{ item.item.title }}'
+    --url='{{ item.item.url }}' --title="${ITEM_TITLE}"
     --admin_name='{{ item.item.admin_name | default('admin') }}'
     --admin_email='{{ item.item.admin_email }}'
     --admin_password='{{ item.item.admin_password }}'


### PR DESCRIPTION
I have a WordPress installation in my list of `wordpress_installs` that has a single-quote character `'` in the title. An example would be something like:

```
      - name: example.com
        path: "/var/www/example.com"
        url: "http://example.com"
        title: "Example User's Weblog"
```

Currently this fails as the `wp-cli core install` command is invoked with the Ansible `{{ item.item.title }}` variable in single quotes, making the shell command unbalanced (https://github.com/Oefenweb/ansible-wordpress/blob/master/tasks/core.yml#L53).

Rather than using `regex_replace` or `replace` on the string, as a workaround, set the `ITEM_TITLE` environment variable, then use it in a double-quoted string. This should preserve behaviour of single quotes, apostrophes, and `$` characters.

Tested with the following config:

```
      - name: example.com
        path: "/var/www/example.com"
        url: "http://example.com"
        title: "Title with Single Quote ' Double Quote \" Dollar Sign $"
        dbname: example_wp
        dbuser: example_wp
        dbpass: NotARealDBPassword
        admin_email: example@example.com
        admin_password: NotARealWPPassword
        themes: []
        plugins: []
        options: []
```

Resulting in the following database value:

```
# mysql example_wp -e "select option_value from wp_options where option_name='blogname'"
+------------------------------------------------------------------+
| option_value                                                     |
+------------------------------------------------------------------+
| Title with Single Quote &#039; Double Quote &quot; Dollar Sign $ |
+------------------------------------------------------------------+
```

I would be amenable to changing the environment variable name if there is a preference, but it should also only persist for this particular task in `core` as per the Ansible documentation (https://docs.ansible.com/ansible/latest/user_guide/playbooks_environment.html).